### PR TITLE
fix button styling bug

### DIFF
--- a/packages/web/src/components/Button/index.tsx
+++ b/packages/web/src/components/Button/index.tsx
@@ -59,6 +59,7 @@ export const Button = (buttonProps: ButtonProps) => {
     selected,
     loaderProps = {},
     debugName,
+    style = {},
     ...props
   } = allProps
 
@@ -105,7 +106,7 @@ export const Button = (buttonProps: ButtonProps) => {
 
   return (
     <Touchable
-      css={_styles.wrapper}
+      css={[_styles.wrapper, style]}
       component='button'
       debugComponent='Button'
       disabled={disabled}


### PR DESCRIPTION
## Overview
* This fixes a bug that causes the button style prop to be overridden by variants

## Were you able to reproduce the issue?
* Whenever a styling object was passed to button by the style prop, its styling was overridden by the variants
 