### PR TITLE
Date Picker fix

### DIFF
--- a/packages/mobile/src/components/DatePickerModal/index.tsx
+++ b/packages/mobile/src/components/DatePickerModal/index.tsx
@@ -113,7 +113,6 @@ export const DatePickerModal = (props: DatePickerModalProps) => {
     footer,
     variants = [],
     styles = {},
-    placeholder = '',
     datePickerProps,
     mode,
     label,
@@ -154,7 +153,8 @@ export const DatePickerModal = (props: DatePickerModalProps) => {
   const tempDate = useRef<Date|null>(null)
 
   const onConfirm = () => {
-    if (commitDate == 'onConfirm') {
+
+    if (commitDate == 'onConfirm' && !!tempDate.current) {
       setValue(tempDate.current)
     }
 


### PR DESCRIPTION
Before this fix, if the user chose the same date that it was already previously setted, the component button would show no date at all, instead of showing the same date.



Video of the bug

https://github.com/codeleap-uk/internal-libs-monorepo/assets/89230082/1d50b752-61ff-41d2-ad3b-0f2d96085701


