### PR TITLE
Select (web): loadInitialValue prop

### DIFF
--- a/packages/web/src/components/Select/index.tsx
+++ b/packages/web/src/components/Select/index.tsx
@@ -238,7 +238,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
     const [selectedOption, setSelectedOption] = hasSelectedOptionState ? [_selectedOption, _setSelectedOption] : useState(initialValue ?? value)
 
     const [_isFocused, setIsFocused] = useState(false)
-
+    const [loadedOptions, setLoadedOptions] = useState(false)
     const [keyDownActive, setKeyDownActive] = useState(false)
 
     const isFocused = _isFocused || focused
@@ -282,10 +282,12 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
             return options
           })
 
-          if (loadInitialValue && !TypeGuards.isNil(_options)) {
+          if (loadInitialValue && !TypeGuards.isNil(_options) && !loadedOptions) {
             const _initialValue = _options?.find?.((option) => option?.value === value)
             if (!!_initialValue) setSelectedOption(_initialValue)
           }
+
+          setLoadedOptions(true)
 
           return _options
         } catch (err) {

--- a/packages/web/src/components/Select/index.tsx
+++ b/packages/web/src/components/Select/index.tsx
@@ -169,6 +169,7 @@ const defaultProps: Partial<SelectProps> = {
   loadingIndicatorSize: 20,
   options: [],
   loadInitialValue: false,
+  loadingMessage: 'loading...',
 }
 
 export const Select = forwardRef<HTMLInputElement, SelectProps>(
@@ -223,6 +224,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       loadingIndicatorSize,
       selectedOption: _selectedOption,
       setSelectedOption: _setSelectedOption,
+      loadingMessage,
       ...otherProps
     } = selectProps
 
@@ -414,7 +416,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
           ref={innerInputRef}
           closeMenuOnSelect={closeOnSelect}
           menuPortalTarget={innerWrapperRef.current}
-          placeholder={placeholder}
+          placeholder={(loadOptionsOnMount && !loadedOptions) ? loadingMessage : placeholder}
           isDisabled={isDisabled}
           isClearable={clearable}
           isSearchable={searchable}

--- a/packages/web/src/components/Select/index.tsx
+++ b/packages/web/src/components/Select/index.tsx
@@ -168,6 +168,7 @@ const defaultProps: Partial<SelectProps> = {
   itemProps: {} as ButtonProps,
   loadingIndicatorSize: 20,
   options: [],
+  loadInitialValue: false,
 }
 
 export const Select = forwardRef<HTMLInputElement, SelectProps>(
@@ -195,6 +196,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       loadOptions,
       multiple,
       limit = null,
+      loadInitialValue,
       focused,
       _error,
       renderItem: OptionComponent = null,
@@ -229,7 +231,11 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
 
     const hasSelectedOptionState = !TypeGuards.isNil(_selectedOption) && TypeGuards.isFunction(_setSelectedOption)
 
-    const [selectedOption, setSelectedOption] = hasSelectedOptionState ? [_selectedOption, _setSelectedOption] : useState(value)
+    const initialValue = (loadInitialValue && !TypeGuards.isNil(options)) 
+      ? options?.find((option) => option?.value === value) 
+      : value 
+
+    const [selectedOption, setSelectedOption] = hasSelectedOptionState ? [_selectedOption, _setSelectedOption] : useState(initialValue ?? value)
 
     const [_isFocused, setIsFocused] = useState(false)
 
@@ -275,6 +281,11 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
             cb(options)
             return options
           })
+
+          if (loadInitialValue && !TypeGuards.isNil(_options)) {
+            const _initialValue = _options?.find?.((option) => option?.value === value)
+            if (!!_initialValue) setSelectedOption(_initialValue)
+          }
 
           return _options
         } catch (err) {

--- a/packages/web/src/components/Select/types.ts
+++ b/packages/web/src/components/Select/types.ts
@@ -93,6 +93,7 @@ export type SelectProps<T = any, Multi extends boolean = false> = React.PropsWit
     itemProps?: ButtonProps
     loadingIndicatorSize?: number
     limit?: number
+    loadInitialValue?: boolean
     selectedOption?: ReactSelectProps<T>['value']
     setSelectedOption?: ReactSelectProps<T>['onValueChange']
   } & Omit<

--- a/packages/web/src/components/Select/types.ts
+++ b/packages/web/src/components/Select/types.ts
@@ -94,6 +94,7 @@ export type SelectProps<T = any, Multi extends boolean = false> = React.PropsWit
     loadingIndicatorSize?: number
     limit?: number
     loadInitialValue?: boolean
+    loadingMessage?: string
     selectedOption?: ReactSelectProps<T>['value']
     setSelectedOption?: ReactSelectProps<T>['onValueChange']
   } & Omit<


### PR DESCRIPTION
### Overview

The lib we use for Select needs the value to be equal to one of the options, and currently the value that is set in the initial value is the value of an option and not an option itself, this prop looks for the option that corresponds to the value passed and arrow on state