### PR TITLE
Image webp conversion script

### DIFF
--- a/packages/cli/src/commands/convertorWebp.ts
+++ b/packages/cli/src/commands/convertorWebp.ts
@@ -1,0 +1,126 @@
+import { codeleapCommand } from '../lib/Command'
+import fs from 'fs'
+import path from 'path'
+import sharp from 'sharp'
+import { inquirer } from '../lib'
+import '../lib/firebase'
+
+type Settings = {
+  input: string
+  output: string
+  convertor: {
+    compressionQuality: number
+    resizeWidth: number
+    inputFormats: string[]
+    ignoreFiles: string[]
+  }
+}
+
+const commandName = 'convertor-webp'
+
+export const convertorWebpCommand = codeleapCommand(
+  {
+    name: commandName,
+    parameters: [
+      '[settingsPath]',
+    ],
+    help: {
+      description: 'Command for easily convertor to webp, compression and resize images.',
+      examples: [
+        `codeleap ${commandName} ./src/app/assets/convertor.settings.json`,
+      ],
+    },
+  },
+  async (argv) => {
+    const { flags, _ } = argv
+    
+    let settingsPath = _.settingsPath
+
+    if (!settingsPath) {
+      const answers = await inquirer.prompt([
+        {
+          message: `Please insert the settings path.`,
+          name: 'settings',
+        },
+      ])
+
+      settingsPath = answers.settings
+    }
+
+    if (!fs.existsSync(settingsPath)) {
+      console.error('Settings not found, check path:', settingsPath)
+      return
+    }
+
+    const settingsJSON = fs.readFileSync(settingsPath).toString()
+
+    let settings: Settings = JSON.parse(settingsJSON)
+
+    console.log('Starting conversion', settings)
+
+    if (!fs.existsSync(settings.output)) {
+      fs.mkdirSync(settings.output)
+    }
+    
+    let files = []
+
+    if (fs.existsSync(settings.input)) {
+      const inputFiles: string[] = fs.readdirSync(settings.input)
+
+      for (const inputFile of inputFiles) {
+        const isCorrectFormat = settings?.convertor?.inputFormats?.some(
+          _format => inputFile?.endsWith(_format)
+        )
+
+        const isIgnoredFile = settings.convertor.ignoreFiles.includes(inputFile?.split('.')[0])
+
+        if (isCorrectFormat && !isIgnoredFile) {
+          files.push(inputFile)
+        }
+      }
+
+    } else {
+      console.error('Input folder not found, check settings', settings)
+      return
+    }
+
+    console.log('Files to convert', files)
+
+    for (const file of files) {
+      const inputPath = path.join(settings.input, file);
+      const outputPath = path.join(settings.output, path.parse(file).name + '.webp')
+
+      if (fs.existsSync(outputPath)) {
+        fs.unlinkSync(outputPath)
+      }
+
+      const img = sharp(inputPath)
+      const img_metadata = await img.metadata()
+
+      let imageProcessing = img.webp({ quality: Number(settings?.convertor?.compressionQuality) })
+
+      const needResize = img_metadata?.width && img_metadata?.width > settings?.convertor?.resizeWidth
+
+      if (needResize) {
+        const newWidth = parseInt(String(settings?.convertor?.resizeWidth))
+        const newHeight = parseInt(String(img_metadata.height * (newWidth / img_metadata.width)))
+
+        imageProcessing = imageProcessing.resize({ width: newWidth, height: newHeight })
+      }
+
+      const hasAlfaChannels = img_metadata.channels && img_metadata.channels >= 4
+
+      if (hasAlfaChannels) {
+        imageProcessing = imageProcessing.toColorspace('srgb')
+      }
+
+      imageProcessing.toFile(outputPath, (err, info) => {
+        if (err) {
+          console.error(`Error converting ${file} to webP`, err)
+        } else {
+          console.log(`Image ${file} converted to webP`, info)
+        }
+      })
+    }
+  },
+)

--- a/packages/cli/src/commands/convertorWebp.ts
+++ b/packages/cli/src/commands/convertorWebp.ts
@@ -23,11 +23,6 @@ export const convertorWebpCommand = codeleapCommand(
   async (argv) => {
     const { flags, _ } = argv
     
-    let settingsPath = _.settingsPath
-
-    if (!settingsPath) {
-      const answers = await inquirer.prompt([
-        {
     let settingsPath = CODELEAP_CLI_SETTINGS_PATH
 
     if (!fs.existsSync(settingsPath)) {

--- a/packages/cli/src/commands/convertorWebp.ts
+++ b/packages/cli/src/commands/convertorWebp.ts
@@ -16,7 +16,7 @@ export const convertorWebpCommand = codeleapCommand(
     help: {
       description: 'Command for easily convertor to webp, compression and resize images.',
       examples: [
-        `codeleap ${commandName} ./src/app/assets/convertor.settings.json`,
+        `codeleap ${commandName}`,
       ],
     },
   },

--- a/packages/cli/src/commands/convertorWebp.ts
+++ b/packages/cli/src/commands/convertorWebp.ts
@@ -23,7 +23,7 @@ export const convertorWebpCommand = codeleapCommand(
   async (argv) => {
     const { flags, _ } = argv
     
-    let settingsPath = CODELEAP_CLI_SETTINGS_PATH
+    const settingsPath = CODELEAP_CLI_SETTINGS_PATH
 
     if (!fs.existsSync(settingsPath)) {
       console.error('Settings not found, check path:', settingsPath)
@@ -62,6 +62,7 @@ export const convertorWebpCommand = codeleapCommand(
           error: e,
         })
         process.exit(1)
+        return
       }
     }
     

--- a/packages/cli/src/commands/convertorWebp.ts
+++ b/packages/cli/src/commands/convertorWebp.ts
@@ -124,7 +124,7 @@ export const convertorWebpCommand = codeleapCommand(
 
       const hasAlfaChannels = img_metadata.channels && img_metadata.channels >= 4
 
-      if (hasAlfaChannels) {
+      if (hasAlfaChannels && !!settings.convertor.processColorChannels) {
         imageProcessing = imageProcessing.toColorspace('srgb')
       }
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -26,3 +26,5 @@ export const USER_CONFIG = {
   ... _userConf
 }
 export const MOBILE_TEMPLATE_URL = `git@github.com:${orgName}/mobile-template.git`
+
+export const CODELEAP_CLI_SETTINGS_PATH = './codeleapcli.config.json'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { downloadKeystores } from './commands/downloadKeystores'
 import { generateReleaseKey } from './commands/keystoresAndroid'
 import { renameMobileCommand } from './commands/rename'
 import { syncIconsCommand } from './commands/syncIcons'
+import { convertorWebpCommand } from './commands/convertorWebp'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJson = require('../package.json')
@@ -18,7 +19,8 @@ cli({
     createAppCommand, 
     configureCommand,
     downloadKeystores,
-    syncIconsCommand
+    syncIconsCommand,
+    convertorWebpCommand
   ],
   version: packageJson.version,
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,4 +1,18 @@
 export type CodeleapCLIUserConfig = {
-    GITHUB_TOKEN: string
-    SHELL?: string
+  GITHUB_TOKEN: string
+  SHELL?: string
+}
+
+export type CodeleapCLISettings = {
+  'convertor-webp': {
+    input: string
+    output: string
+    convertor: {
+      compressionQuality: number
+      resizeWidth: number
+      inputFormats: string[]
+      ignoreFiles: string[]
+    }
+    mode: 'multi' | 'single'
+  }
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -10,6 +10,7 @@ export type CodeleapCLISettings = {
     convertor: {
       compressionQuality: number
       resizeWidth: number
+      processColorChannels: boolean
       inputFormats: string[]
       ignoreFiles: string[]
     }


### PR DESCRIPTION
### Overview

Script to convert images to webp, compress and resize to reduce their size and improve loading speed in browsers. Everything completely configurable through a JSON file.

Example of settings that transformed a 54 KB file to 12 KB:

```.json
{
  "convertor-webp": {
    "input": "./src/app/assets/images",
    "output": "./src/app/assets/images_webp",
    "convertor": {
      "compressionQuality": 50,
      "resizeWidth": 1000,
      "processColorChannels": true,
      "inputFormats": ["png", "jpeg"],
      "ignoreFiles": []
    },
    "mode": "multi"
  }
}
```
> Task

- https://www.notion.so/codeleap/Image-webp-conversion-script-228038f052d34c6e8da70a4101efdac1?pvs=4