### PR TITLE
fix-color-variant

### DIFF
--- a/packages/common/src/styles/variants/utils.ts
+++ b/packages/common/src/styles/variants/utils.ts
@@ -91,12 +91,14 @@ export function applyVariants({
     } else if (variantName.startsWith('backgroundColor') || variantName.startsWith('bg') || variantName.startsWith('color')) {
       let [property, themeColor] = variantName.split(':')
 
+      const _rootElement = variantName.startsWith('color') ? (rootElement === 'text' ? rootElement : 'text') : rootElement
+
       if (property === 'bg') property = 'backgroundColor'
 
       const value = theme.colors[themeColor]
       const browserOnly = theme.IsBrowser && { fill: value, stroke: value }
       return deepMerge(computedStyles, {
-        [rootElement]: wrapStyle({
+        [_rootElement]: wrapStyle({
           [property]: value,
           ...browserOnly,
         }),


### PR DESCRIPTION
variants that start with color (like 'color:neutral5') are now always applied to the text component, regardless of the root element being a text or not (like on the Button component for example)