### PR TITLE
Fix usePopState was clearing search params

### DIFF
--- a/packages/web/src/lib/usePopState.ts
+++ b/packages/web/src/lib/usePopState.ts
@@ -1,9 +1,14 @@
 import { AnyFunction, useIsomorphicEffect, useUnmount } from '@codeleap/common'
 
 export const usePopState = (dependence: boolean, handler: AnyFunction) => {
+
   useIsomorphicEffect(() => {
     if (dependence) {
-      window.history.pushState(null, null, window.location.pathname)
+      const pathname = location.pathname
+      const searchParams = location.search
+      const newUrl = pathname + searchParams
+
+      window.history.pushState(null, null, newUrl)
       window.addEventListener('popstate', handler)
     } else {
       window.removeEventListener('popstate', handler)


### PR DESCRIPTION
## Issue
When open an modal with query params in URL, the modal was cleaning the query params

## Overview
* Fix usePopState hook, adding search params into pushState
