### PR TITLE
Change RenderItem to be a function

### DIFF
--- a/packages/mobile/src/components/List/index.tsx
+++ b/packages/mobile/src/components/List/index.tsx
@@ -29,7 +29,7 @@ export const List = forwardRef<FlatList, FlatListProps>((flatListProps, ref) => 
     keyboardAware,
     fakeEmpty = loading,
     contentContainerStyle,
-    renderItem: RenderItem,
+    renderItem: _renderItem,
     data,
     ...props
   } = {
@@ -44,7 +44,7 @@ export const List = forwardRef<FlatList, FlatListProps>((flatListProps, ref) => 
   const dataLength = data?.length || 0
 
   const renderItem = useCallback((data: ListRenderItemInfo<any>) => {
-    if (!RenderItem) return null
+    if (!_renderItem) return null
 
     const isFirst = data.index === 0
     const isLast = data.index === dataLength - 1
@@ -58,8 +58,8 @@ export const List = forwardRef<FlatList, FlatListProps>((flatListProps, ref) => 
       isOnly,
     }
 
-    return <RenderItem {...itemProps} />
-  }, [dataLength, RenderItem])
+    return _renderItem(itemProps)
+  }, [dataLength, _renderItem])
 
   const isEmpty = !data || !data?.length
 


### PR DESCRIPTION
## The problem
The main problem with using RenderItem as component, is because we were recreating the return of renderItem, even with memo in the component, so the idea is change to a function.